### PR TITLE
Small fix to exportDbToSql() method

### DIFF
--- a/www/sqlitePorter.js
+++ b/www/sqlitePorter.js
@@ -182,11 +182,16 @@
                                 var row = results.rows.item(i);
                                 if (row.sql != null && row.sql.indexOf("CREATE TABLE") != -1 && row.sql.indexOf("__") == -1) {
                                     var tableName = sqlUnescape(trimWhitespace(trimWhitespace(row.sql.replace("CREATE TABLE", "")).split(/ |\(/)[0]));
-                                    sqlStatements.push("DROP TABLE IF EXISTS " + sqlEscape(tableName));
+                                    /*Added checking for reserved tables in order to prevent even that DROP and CREATE statements for reserved tables be added to the exported sql*/
+                                    if(!isReservedTable(tableName)){ 
+                                        sqlStatements.push(row.sql);
+                                        sqlStatements.push("DROP TABLE IF EXISTS " + sqlEscape(tableName));
+                                    }
                                 }
-                                if(row.sql != null && row.sql.indexOf("__") == -1){
-                                    sqlStatements.push(row.sql);
-                                }
+                                /*commented following lines because the core code has been added in the previous block*/
+//                                if(row.sql != null && row.sql.indexOf("__") == -1){
+//                                    sqlStatements.push(row.sql);
+//                                }
                             }
                         }
 


### PR DESCRIPTION
Prevent from adding CREATE and DROP statements for reserved tables in exportDbToSql() method.